### PR TITLE
Prepare for adoption of new iOS 17 WidgetKit APIs

### DIFF
--- a/PiStatsMobile/PiStatsMobile.xcodeproj/project.pbxproj
+++ b/PiStatsMobile/PiStatsMobile.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		31E153072523AD61008DD6CD /* PiMonitorWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E153012523AD44008DD6CD /* PiMonitorWidgetView.swift */; };
 		31E153102523AD69008DD6CD /* PiMonitorWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E152FB2523AC62008DD6CD /* PiMonitorWidget.swift */; };
 		31FC1DAA24B64BA900319E6F /* PiholeDataProviderListManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FC1DA924B64BA900319E6F /* PiholeDataProviderListManager.swift */; };
+		F4F9189A2A392B5A00CA4CDC /* BackDeployableShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F918992A392B5A00CA4CDC /* BackDeployableShims.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -209,6 +210,7 @@
 		F4B4BF7A2A38AA3B00C3B9BA /* Main.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Main.xcconfig; sourceTree = "<group>"; };
 		F4B4BF7B2A38AA3B00C3B9BA /* OpenSource.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = OpenSource.xcconfig; sourceTree = "<group>"; };
 		F4B4BF7C2A38AA3B00C3B9BA /* TeamID.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TeamID.xcconfig; sourceTree = "<group>"; };
+		F4F918992A392B5A00CA4CDC /* BackDeployableShims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackDeployableShims.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -276,6 +278,7 @@
 				310647CD24BD115F00E2DA90 /* SmallStatsItem.swift */,
 				310647D124BD13D700E2DA90 /* MediumStatsItem.swift */,
 				310647CF24BD120600E2DA90 /* PiStatsDisplayWidgetView.swift */,
+				F4F918992A392B5A00CA4CDC /* BackDeployableShims.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -750,6 +753,7 @@
 				315F5ED924BA2D0C00FED38F /* APIToken.swift in Sources */,
 				310647D024BD120600E2DA90 /* PiStatsDisplayWidgetView.swift in Sources */,
 				315F5ED124BA1DF800FED38F /* StatsItemType.swift in Sources */,
+				F4F9189A2A392B5A00CA4CDC /* BackDeployableShims.swift in Sources */,
 				31E153072523AD61008DD6CD /* PiMonitorWidgetView.swift in Sources */,
 				315F5EC524BA162600FED38F /* ViewStatsWidget.swift in Sources */,
 				317636AB25265AB7005AED55 /* PiMonitorView.swift in Sources */,
@@ -910,6 +914,7 @@
 				CODE_SIGN_ENTITLEMENTS = PiStatsWidget/PiStatsWidgetExtension.entitlements;
 				CURRENT_PROJECT_VERSION = 19;
 				INFOPLIST_FILE = PiStatsWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -932,6 +937,7 @@
 				CODE_SIGN_ENTITLEMENTS = PiStatsWidget/PiStatsWidgetExtension.entitlements;
 				CURRENT_PROJECT_VERSION = 19;
 				INFOPLIST_FILE = PiStatsWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1320,6 +1326,7 @@
 				CODE_SIGN_ENTITLEMENTS = PiStatsWidget/PiStatsWidgetExtension.entitlements;
 				CURRENT_PROJECT_VERSION = 19;
 				INFOPLIST_FILE = PiStatsWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1480,6 +1487,7 @@
 				CODE_SIGN_ENTITLEMENTS = PiStatsWidget/PiStatsWidgetExtension.entitlements;
 				CURRENT_PROJECT_VERSION = 19;
 				INFOPLIST_FILE = PiStatsWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/PiStatsMobile/PiStatsMobile.xcodeproj/xcshareddata/xcschemes/PiStatsWidgetExtension.xcscheme
+++ b/PiStatsMobile/PiStatsMobile.xcodeproj/xcshareddata/xcschemes/PiStatsWidgetExtension.xcscheme
@@ -79,8 +79,8 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "_XCWidgetKind"
-            value = ""
-            isEnabled = "NO">
+            value = "PiMonitorWidget"
+            isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "_XCWidgetDefaultView"
@@ -89,8 +89,13 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "_XCWidgetFamily"
-            value = "medium"
-            isEnabled = "NO">
+            value = "systemSmall"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetKind"
+            value = "ViewStatsWidget"
+            isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/PiStatsMobile/PiStatsWidget/PiMonitorWidget.swift
+++ b/PiStatsMobile/PiStatsWidget/PiMonitorWidget.swift
@@ -42,12 +42,15 @@ struct PiMonitorWidget_Previews: PreviewProvider {
     static var previews: some View {
         
         PiMonitorWidgetView(entry: PiholeEntry(piholeDataProvider: PiholeDataProvider.previewData(), date: Date(), widgetFamily: .systemSmall))
+            .disableContentMarginsForPreview()
             .previewContext(WidgetPreviewContext(family: .systemSmall))
 
         PiMonitorWidgetView(entry: PiholeEntry(piholeDataProvider: PiholeDataProvider.previewData(), date: Date(), widgetFamily: .systemMedium))
+            .disableContentMarginsForPreview()
             .previewContext(WidgetPreviewContext(family: .systemMedium))
         
         PlaceholderView()
+            .disableContentMarginsForPreview()
             .previewContext(WidgetPreviewContext(family: .systemSmall))
     }
 }

--- a/PiStatsMobile/PiStatsWidget/PiMonitorWidget.swift
+++ b/PiStatsMobile/PiStatsWidget/PiMonitorWidget.swift
@@ -10,16 +10,15 @@ import SwiftUI
 
 private struct PlaceholderView : View {
     var body: some View {
-        
-        PiMonitorView(provider: PiholeDataProvider.previewData(), shouldDisplayStats: false ).redacted(reason: .placeholder)
+        PiMonitorView(provider: PiholeDataProvider.previewData(), shouldDisplayStats: false )
+            .redacted(reason: .placeholder)
     }
 }
 
 struct PiMonitorWidget: Widget {
     private let kind: String = "PiMonitorWidget"
     public var body: some WidgetConfiguration {
-        
-        IntentConfiguration(
+        let config = IntentConfiguration(
             kind: "dev.bunn.PiStatsMobile.SelectPiholeIntent",
             intent: SelectPiholeIntent.self,
             provider: PiMonitorTimelineProvider()
@@ -29,6 +28,12 @@ struct PiMonitorWidget: Widget {
         .configurationDisplayName("Pi Monitor")
         .description("Display metrics for your Raspberry Pi")
         .supportedFamilies([.systemSmall, .systemMedium])
+
+        if #available(iOSApplicationExtension 17.0, *) {
+            return config.contentMarginsDisabled()
+        } else {
+            return config
+        }
     }
 }
 

--- a/PiStatsMobile/PiStatsWidget/ViewStatsWidget.swift
+++ b/PiStatsMobile/PiStatsWidget/ViewStatsWidget.swift
@@ -20,6 +20,7 @@ private struct PlaceholderView : View {
                 StatsItemType.domainsOnBlockList.color
             }
         }
+        .widgetBackground()
     }
 }
 
@@ -27,28 +28,36 @@ struct ViewStatsWidget: Widget {
     private let kind: String = "ViewStatsWidget"
     
     public var body: some WidgetConfiguration {
-        StaticConfiguration(kind: kind, provider: PiholeTimelineProvider()) { entry in
+        let config = StaticConfiguration(kind: kind, provider: PiholeTimelineProvider()) { entry in
             PiStatsDisplayWidgetView(entry: entry)
         }
         .configurationDisplayName("Pi Stats")
         .description("Display the status of your pi-holes")
         .supportedFamilies([.systemSmall, .systemMedium])
+
+        if #available(iOSApplicationExtension 17.0, *) {
+            return config.contentMarginsDisabled()
+        } else {
+            return config
+        }
     }
 }
 
-
 struct ViewStatsWidget_Previews: PreviewProvider {
+    /// NOTE: Previews do not respect `contentMarginsDisabled` from widget because they use the view directly,
+    /// so margins will not look correct in Xcode Previews.
     static var previews: some View {
-        
         PiStatsDisplayWidgetView(entry: PiholeEntry(piholeDataProvider: PiholeDataProvider.previewData(), date: Date(), widgetFamily: .systemSmall))
             .previewContext(WidgetPreviewContext(family: .systemSmall))
+            .previewDisplayName("System Small")
 
         PiStatsDisplayWidgetView(entry: PiholeEntry(piholeDataProvider: PiholeDataProvider.previewData(), date: Date(), widgetFamily: .systemMedium))
             .previewContext(WidgetPreviewContext(family: .systemMedium))
-        
+            .previewDisplayName("System Medium")
+
         PlaceholderView()
             .previewContext(WidgetPreviewContext(family: .systemSmall))
-        
+            .previewDisplayName("Placeholder")
     }
 }
 

--- a/PiStatsMobile/PiStatsWidget/ViewStatsWidget.swift
+++ b/PiStatsMobile/PiStatsWidget/ViewStatsWidget.swift
@@ -48,14 +48,17 @@ struct ViewStatsWidget_Previews: PreviewProvider {
     /// so margins will not look correct in Xcode Previews.
     static var previews: some View {
         PiStatsDisplayWidgetView(entry: PiholeEntry(piholeDataProvider: PiholeDataProvider.previewData(), date: Date(), widgetFamily: .systemSmall))
+            .disableContentMarginsForPreview()
             .previewContext(WidgetPreviewContext(family: .systemSmall))
             .previewDisplayName("System Small")
 
         PiStatsDisplayWidgetView(entry: PiholeEntry(piholeDataProvider: PiholeDataProvider.previewData(), date: Date(), widgetFamily: .systemMedium))
+            .disableContentMarginsForPreview()
             .previewContext(WidgetPreviewContext(family: .systemMedium))
             .previewDisplayName("System Medium")
 
         PlaceholderView()
+            .disableContentMarginsForPreview()
             .previewContext(WidgetPreviewContext(family: .systemSmall))
             .previewDisplayName("Placeholder")
     }

--- a/PiStatsMobile/PiStatsWidget/Views/BackDeployableShims.swift
+++ b/PiStatsMobile/PiStatsWidget/Views/BackDeployableShims.swift
@@ -1,0 +1,29 @@
+//
+//  BackDeployableShims.swift
+//  PiStatsWidgetExtension
+//
+//  Created by Guilherme Rambo on 13/06/23.
+//
+
+import SwiftUI
+import WidgetKit
+
+extension View {
+    @ViewBuilder
+    func widgetBackground() -> some View {
+        if #available(iOS 17.0, *) {
+            containerBackground(.background, for: .widget)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func numericContentTransition(countsDown: Bool = false) -> some View {
+        if #available(iOSApplicationExtension 16.0, *) {
+            contentTransition(.numericText(countsDown: countsDown))
+        } else {
+            self
+        }
+    }
+}

--- a/PiStatsMobile/PiStatsWidget/Views/BackDeployableShims.swift
+++ b/PiStatsMobile/PiStatsWidget/Views/BackDeployableShims.swift
@@ -26,4 +26,14 @@ extension View {
             self
         }
     }
+
+    #if DEBUG
+    /// Workaround for WidgetKit previews using old-style PreviewProvider
+    /// not respecting the `contentMarginsDisabled()` modifier
+    /// when previewing on iOS 17 Simulator.
+    @ViewBuilder
+    func disableContentMarginsForPreview() -> some View {
+        padding(-16)
+    }
+    #endif
 }

--- a/PiStatsMobile/PiStatsWidget/Views/MediumStatsItem.swift
+++ b/PiStatsMobile/PiStatsWidget/Views/MediumStatsItem.swift
@@ -27,6 +27,7 @@ struct MediumStatsItem: View {
                     Label(value, systemImage: contentType.imageName)
                         .foregroundColor(.white)
                         .font(.headline)
+                        .numericContentTransition()
                 }
             }
             .padding(.horizontal, UIConstants.Geometry.widgetDefaultPadding)

--- a/PiStatsMobile/PiStatsWidget/Views/PiMonitor/PiMonitorView.swift
+++ b/PiStatsMobile/PiStatsWidget/Views/PiMonitor/PiMonitorView.swift
@@ -61,8 +61,10 @@ struct PiMonitorView: View {
             maxWidth: .infinity,
             maxHeight: .infinity,
             alignment: .topLeading
-        ).padding()
+        )
+        .padding()
         .font(.headline)
+        .widgetBackground()
     }
     
     private func getMetricListItems(_ provider: PiholeDataProvider) -> [ListItem] {

--- a/PiStatsMobile/PiStatsWidget/Views/PiStatsDisplayWidgetView.swift
+++ b/PiStatsMobile/PiStatsWidget/Views/PiStatsDisplayWidgetView.swift
@@ -12,35 +12,38 @@ struct PiStatsDisplayWidgetView : View {
     var entry: PiholeEntry
     
     var body: some View {
-        if entry.widgetFamily == WidgetFamily.systemSmall {
-            ZStack {
-                VStack (spacing:0) {
-                    HStack(spacing:0) {
-                        SmallStatsItem(itemType: StatsItemType.totalQueries, value: entry.piholeDataProvider.totalQueries)
-                        SmallStatsItem(itemType: StatsItemType.queriesBlocked, value: entry.piholeDataProvider.queriesBlocked)
+        ZStack {
+            if entry.widgetFamily == WidgetFamily.systemSmall {
+                ZStack {
+                    VStack (spacing:0) {
+                        HStack(spacing:0) {
+                            SmallStatsItem(itemType: StatsItemType.totalQueries, value: entry.piholeDataProvider.totalQueries)
+                            SmallStatsItem(itemType: StatsItemType.queriesBlocked, value: entry.piholeDataProvider.queriesBlocked)
+                        }
+                        HStack(spacing:0) {
+                            SmallStatsItem(itemType: StatsItemType.percentBlocked, value: entry.piholeDataProvider.percentBlocked)
+                            SmallStatsItem(itemType: StatsItemType.domainsOnBlockList, value: entry.piholeDataProvider.domainsOnBlocklist)
+                        }
                     }
-                    HStack(spacing:0) {
-                        SmallStatsItem(itemType: StatsItemType.percentBlocked, value: entry.piholeDataProvider.percentBlocked)
-                        SmallStatsItem(itemType: StatsItemType.domainsOnBlockList, value: entry.piholeDataProvider.domainsOnBlocklist)
-                    }
+                    CircleBadgeStatus(dataProvider: entry.piholeDataProvider)
                 }
-                CircleBadgeStatus(dataProvider: entry.piholeDataProvider)
-            }
-        } else {
-            ZStack {
-                VStack (alignment:.leading, spacing:0) {
-                    HStack(spacing:0) {
-                        MediumStatsItem(contentType: .totalQueries, value: entry.piholeDataProvider.totalQueries)
-                        MediumStatsItem(contentType: .queriesBlocked, value: entry.piholeDataProvider.queriesBlocked)
+            } else {
+                ZStack {
+                    VStack (alignment:.leading, spacing:0) {
+                        HStack(spacing:0) {
+                            MediumStatsItem(contentType: .totalQueries, value: entry.piholeDataProvider.totalQueries)
+                            MediumStatsItem(contentType: .queriesBlocked, value: entry.piholeDataProvider.queriesBlocked)
+                        }
+                        HStack(spacing:0) {
+                            MediumStatsItem(contentType: .percentBlocked, value: entry.piholeDataProvider.percentBlocked)
+                            MediumStatsItem(contentType: .domainsOnBlockList, value: entry.piholeDataProvider.domainsOnBlocklist)
+                        }
                     }
-                    HStack(spacing:0) {
-                        MediumStatsItem(contentType: .percentBlocked, value: entry.piholeDataProvider.percentBlocked)
-                        MediumStatsItem(contentType: .domainsOnBlockList, value: entry.piholeDataProvider.domainsOnBlocklist)
-                    }
+                    CircleBadgeStatus(dataProvider: entry.piholeDataProvider)
                 }
-                CircleBadgeStatus(dataProvider: entry.piholeDataProvider)
             }
         }
+        .widgetBackground()
     }
 }
 

--- a/PiStatsMobile/PiStatsWidget/Views/SmallStatsItem.swift
+++ b/PiStatsMobile/PiStatsWidget/Views/SmallStatsItem.swift
@@ -24,6 +24,7 @@ struct SmallStatsItem: View {
                     .foregroundColor(.white)
                     .font(.subheadline)
                     .bold()
+                    .numericContentTransition()
             }
         }
     }


### PR DESCRIPTION
This adopts the new `containerBackground` API and uses `contentMarginsDisabled` in order to keep the same look for widgets when built using the iOS 17 SDK. I also took the opportunity to adopt the numeric text content transition which looks really nice for the type of content displayed in PiStats' widgets.

These changes should not interfere with the widget functionality when running on iOS versions before 17.